### PR TITLE
Issue #5

### DIFF
--- a/dateinfer/examples.yaml
+++ b/dateinfer/examples.yaml
@@ -38,6 +38,12 @@ examples:
   - 6/3/85
 ...
 ---
+name: Little Endian
+format: "%d/%m/%Y"
+examples:
+  - 13/1/2012
+...
+---
 name: MLA (dd mmm yyyy)
 format: "%d %B %Y"
 examples:

--- a/dateinfer/infer.py
+++ b/dateinfer/infer.py
@@ -54,6 +54,9 @@ RULES = [
     If(Contains(MonthNum, MonthTextShort), Swap(MonthNum, DayOfMonth)),
     If(Sequence(MonthNum, '.', Hour12), SwapSequence([MonthNum, '.', Hour12], [MonthNum, KeepOriginal, DayOfMonth])),
     If(Sequence(MonthNum, '.', Hour24), SwapSequence([MonthNum, '.', Hour24], [MonthNum, KeepOriginal, DayOfMonth])),
+    If(Sequence(Hour12, '.', MonthNum), SwapSequence([Hour24, '.', MonthNum], [DayOfMonth, KeepOriginal, MonthNum])),
+    If(Sequence(Hour24, '.', MonthNum), SwapSequence([Hour24, '.', MonthNum], [DayOfMonth, KeepOriginal, MonthNum])),
+    If(Duplicate(MonthNum), Swap(MonthNum, DayOfMonth)),
     If(Sequence(F('+'), Year4), SwapSequence([F('+'), Year4], [UTCOffset, None])),
     If(Sequence(F('-'), Year4), SwapSequence([F('+'), Year4], [UTCOffset, None]))
 ]

--- a/dateinfer/tests.py
+++ b/dateinfer/tests.py
@@ -43,6 +43,20 @@ def test_case_for_example(test_data):
     return test_case
 
 
+class TestAmbiguousDateCases(unittest.TestCase):
+    """
+    TestCase for tests which results are ambiguous but can be assumed to fall in a small set of possibilities.
+    """
+    def testAmbg1(self):
+        self.assertIn(infer.infer(['1/1/2012']), ['%m/%d/%Y', '%d/%m/%Y'])
+
+    def testAmbg2(self):
+        # Note: as described in Issue #5 (https://github.com/jeffreystarr/dateinfer/issues/5), the result
+        # should be %d/%m/%Y as the more likely choice. However, at this point, we will allow %m/%d/%Y.
+        self.assertIn(infer.infer(['04/12/2012', '05/12/2012', '06/12/2012', '07/12/2012']),
+                      ['%d/%m/%Y', '%m/%d/%Y'])
+
+
 class TestMode(unittest.TestCase):
     def testMode(self):
         self.assertEqual(5, infer._mode([1, 3, 4, 5, 6, 5, 2, 5, 3]))


### PR DESCRIPTION
Fixed the three example cases by adding extra rules to detect duplicate month entries and change hours to day of month in the unlikely case hours precedes months.

This patch does not deal directly with the third issue -- preferring the smallest probable increment of time when it is varying the greatest within the examples.
